### PR TITLE
Refactor testar api gateway

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,8 @@
 [run]
 omit =
   *apps.py,
+  *__init__.py,
+  *tests.py,
   *migrations/*,
   *settings*,
   *tests/,

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
 stages:
   - Unit test
   
-#notifications:
-#  slack: hora-da-hora:0nFQxr2PykmKhNkJ78xYJMOP
+notifications:
+  slack: hora-da-hora:0nFQxr2PykmKhNkJ78xYJMOP
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose
@@ -23,12 +23,11 @@ jobs:
     - stage: "Unit test"
       name: "Unit test"
       script:
-        - make build
-        - docker network create api-backend
-        - make run-d
-        - make tests
-        #- docker-compose exec api_gateway flake8
-        #- docker-compose exec api_gateway codecov -t ${CODECOV_TOKEN}
+        - make run-dc-tests
+        - make run-tests
+        - make cov-tests
+        # - docker-compose exec api_gateway flake8
+        - docker-compose exec api_gateway codecov -t ${CODECOV_TOKEN}
         
 after_success:
   - docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,7 @@ run-d:
 
 down:
 	docker-compose -f docker-compose.yml down
-
-tests:
-	docker exec api_gateway bash -c "bash run-tests.sh"
-
+	
 run-tests:
 	docker-compose exec api_gateway coverage run manage.py test
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-build:
-	docker-compose -f docker-compose.yml build
-
 run:
 	docker-compose -f docker-compose.yml up
 
@@ -11,5 +8,15 @@ down:
 	docker-compose -f docker-compose.yml down
 
 tests:
-	docker-compose exec api_gateway py.test --cov=.
-	
+	docker exec api_gateway bash -c "bash run-tests.sh"
+
+run-tests:
+	docker-compose exec api_monitoria coverage run manage.py test
+
+cov-tests:
+	docker-compose exec api_monitoria coverage report -m
+
+run-dc-tests:
+	docker network create api-backend 
+	docker-compose -f docker-compose.yml build
+	docker-compose -f docker-compose.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ tests:
 	docker exec api_gateway bash -c "bash run-tests.sh"
 
 run-tests:
-	docker-compose exec api_monitoria coverage run manage.py test
+	docker-compose exec api_gateway coverage run manage.py test
 
 cov-tests:
-	docker-compose exec api_monitoria coverage report -m
+	docker-compose exec api_gateway coverage report -m
 
 run-dc-tests:
 	docker network create api-backend 

--- a/api_gateway/tests.py
+++ b/api_gateway/tests.py
@@ -82,7 +82,7 @@ class MonitoringRedirectTests(APITestCase):
         self.assertEqual(response.status_code, status)
         self.assertEqual(response.data, data)
 
-    def teste_error_delete_tutoring(self, *kwargs):
+    def teste_error_delete_tutoring(self, **kwargs):
         id= self.valid_payload
         api_url = '/delete_tutoring/'
         data = {'error': 'Error no servidor'}

--- a/api_gateway/tests.py
+++ b/api_gateway/tests.py
@@ -1,3 +1,46 @@
-from django.test import TestCase
+from api_gateway.views import all_tutoring
+import requests_mock
+from rest_framework.test import APITestCase
+import json
 
-# Create your tests here.
+from rest_framework.status import (
+    HTTP_403_FORBIDDEN,
+    HTTP_200_OK,
+    HTTP_404_NOT_FOUND,
+    HTTP_400_BAD_REQUEST,
+    HTTP_500_INTERNAL_SERVER_ERROR
+)
+
+class MonitoringRedirectTests(APITestCase):
+    # def setUp(self):
+    #     self.valid_payload = {
+    #         'name': 'teste'
+    #     }
+
+    #     self.invalid_payload = {
+    #         'name': ''
+    #     }
+    
+    @requests_mock.Mocker(kw='mock')
+    def test_all_tutoring(self, **kwargs):
+        api_url = '/all_tutoring/'
+        request_url = 'http://api-monitoria:8001/tutoring/'
+        status = HTTP_200_OK
+        data = {"Teste": "teste"}
+
+        kwargs['mock'].get(request_url, text=json.dumps(data))
+
+        response = self.client.get(api_url)
+
+        self.assertEqual(response.status_code, status)
+        self.assertEqual(response.data['Teste'], "teste")
+
+    def test_error_all_tutoring(self, **kwargs):
+        api_url = '/all_tutoring/'
+        status = HTTP_500_INTERNAL_SERVER_ERROR
+        data = {'error': 'Error no servidor'}
+
+        response = self.client.get(api_url)
+
+        self.assertEqual(response.status_code, status)
+        self.assertEqual(response.data, data)

--- a/api_gateway/tests.py
+++ b/api_gateway/tests.py
@@ -50,15 +50,25 @@ class MonitoringRedirectTests(APITestCase):
         id = self.valid_payload
         api_url = '/get_tutoring/'
         request_url = 'http://api-monitoria:8001/tutoring/1/'
+
         status = HTTP_200_OK
-        data = {'error': 'Error no servidor'}
+        data = {'Teste': 'teste'}
         kwargs['mock'].get(request_url,text = json.dumps(data))
 
         response = self.client.post(api_url,id)
         self.assertEqual(response.status_code, status)
-        self.assertEqual(response.data['error'] ,'Error no servidor'  )
+        self.assertEqual(response.data['Teste'] ,'teste'  )
 
+    def teste_error_get_tutoring(self, **kwargs):
+        id = self.valid_payload
+        api_url = '/get_tutoring/'
 
+        status = HTTP_500_INTERNAL_SERVER_ERROR
+        data = {'error': 'Error no servidor'} 
+        response = self.client.post(api_url,id)
+        self.assertEqual(response.status_code, status)
+        self.assertEqual(response.data ,data  )
+        
 
 
     # @requests_mock.Mocker(kw='mock')

--- a/api_gateway/tests.py
+++ b/api_gateway/tests.py
@@ -69,31 +69,25 @@ class MonitoringRedirectTests(APITestCase):
         self.assertEqual(response.status_code, status)
         self.assertEqual(response.data ,data  )
         
+    @requests_mock.Mocker(kw= 'mock')    
+    def teste_delete_tutoring(self, **kwargs):
+        id= self.valid_payload
+        api_url = '/delete_tutoring/'
+        request_url = 'http://api-monitoria:8001/tutoring/1/'
+        data = {"Success":"Excluido com sucesso"}
+        status = HTTP_200_OK
 
+        kwargs['mock'].delete(request_url, text= json.dumps(data))
+        response = self.client.post(api_url, id)
+        self.assertEqual(response.status_code, status)
+        self.assertEqual(response.data, data)
 
-    # @requests_mock.Mocker(kw='mock')
-    # def test_all_tutoring(self, **kwargs):
-    #     api_url = '/tutoring/'
-    #     request_url = 'http://api-monitoria:8001/tutoring/'
-    #     status = HTTP_200_OK
-    #     data = {"Teste": "teste"}
-
-    #     kwargs['mock'].get(request_url, text=json.dumps(data))
-
-    #     response = self.client.get(api_url)
-
-    #     self.assertEqual(response.status_code, status)
-    #     self.assertEqual(response.data['Teste'], "teste")
-
-    # def test_error_all_tutoring(self, **kwargs):
-    #     api_url = '/all_tutoring/'
-    #     status = HTTP_500_INTERNAL_SERVER_ERROR
-    #     data = {'error': 'Error no servidor'}
-
-    #     response = self.client.get(api_url)
-
-    #     self.assertEqual(response.status_code, status)
-    #     self.assertEqual(response.data, data)
-
-
-
+    def teste_error_delete_tutoring(self, *kwargs):
+        id= self.valid_payload
+        api_url = '/delete_tutoring/'
+        data = {'error': 'Error no servidor'}
+        status =HTTP_500_INTERNAL_SERVER_ERROR
+        response = self.client.post(api_url, id)
+        self.assertEqual(response.status_code, status)
+        self.assertEqual(response.data, data)
+  

--- a/api_gateway/tests.py
+++ b/api_gateway/tests.py
@@ -12,10 +12,10 @@ from rest_framework.status import (
 )
 
 class MonitoringRedirectTests(APITestCase):
-    # def setUp(self):
-    #     self.valid_payload = {
-    #         'name': 'teste'
-    #     }
+    def setUp(self):
+        self.valid_payload = {
+            'id_tutoring_session': '1'
+        }
 
     #     self.invalid_payload = {
     #         'name': ''
@@ -44,3 +44,46 @@ class MonitoringRedirectTests(APITestCase):
 
         self.assertEqual(response.status_code, status)
         self.assertEqual(response.data, data)
+
+    @requests_mock.Mocker(kw='mock')
+    def test_get_tutoring(self, **kwargs):
+        id = self.valid_payload
+        api_url = '/get_tutoring/'
+        request_url = 'http://api-monitoria:8001/tutoring/1/'
+        status = HTTP_200_OK
+        data = {'error': 'Error no servidor'}
+        kwargs['mock'].get(request_url,text = json.dumps(data))
+
+        response = self.client.post(api_url,id)
+        self.assertEqual(response.status_code, status)
+        self.assertEqual(response.data['error'] ,'Error no servidor'  )
+
+
+
+
+    # @requests_mock.Mocker(kw='mock')
+    # def test_all_tutoring(self, **kwargs):
+    #     api_url = '/tutoring/'
+    #     request_url = 'http://api-monitoria:8001/tutoring/'
+    #     status = HTTP_200_OK
+    #     data = {"Teste": "teste"}
+
+    #     kwargs['mock'].get(request_url, text=json.dumps(data))
+
+    #     response = self.client.get(api_url)
+
+    #     self.assertEqual(response.status_code, status)
+    #     self.assertEqual(response.data['Teste'], "teste")
+
+    # def test_error_all_tutoring(self, **kwargs):
+    #     api_url = '/all_tutoring/'
+    #     status = HTTP_500_INTERNAL_SERVER_ERROR
+    #     data = {'error': 'Error no servidor'}
+
+    #     response = self.client.get(api_url)
+
+    #     self.assertEqual(response.status_code, status)
+    #     self.assertEqual(response.data, data)
+
+
+

--- a/api_gateway/tests.py
+++ b/api_gateway/tests.py
@@ -113,4 +113,26 @@ class MonitoringRedirectTests(APITestCase):
         status =HTTP_500_INTERNAL_SERVER_ERROR
         response = self.client.post(api_url, id)
         self.assertEqual(response.status_code, status)
+        self.assertEqual(response.data, data)  
+
+    @requests_mock.Mocker(kw= 'mock')    
+    def teste_update_tutoring(self, **kwargs):
+        id= self.valid_payload
+        api_url = '/update_tutoring/'
+        request_url = 'http://api-monitoria:8001/tutoring/1/'
+        data = {"Success":"Alterado com sucesso"}
+        status = HTTP_200_OK
+        
+        kwargs['mock'].put(request_url, text= json.dumps(data))
+        response = self.client.post(api_url, id)
+        self.assertEqual(response.status_code, status)
+        self.assertEqual(response.data, data)
+
+    def teste_error_update_tutoring(self, **kwargs):
+        id= self.valid_payload
+        api_url = '/delete_tutoring/'
+        data = {'error': 'Error no servidor'}
+        status =HTTP_500_INTERNAL_SERVER_ERROR
+        response = self.client.post(api_url, id)
+        self.assertEqual(response.status_code, status)
         self.assertEqual(response.data, data)

--- a/api_gateway/tests.py
+++ b/api_gateway/tests.py
@@ -76,7 +76,7 @@ class MonitoringRedirectTests(APITestCase):
         request_url = 'http://api-monitoria:8001/tutoring/1/'
         data = {"Success":"Excluido com sucesso"}
         status = HTTP_200_OK
-
+        
         kwargs['mock'].delete(request_url, text= json.dumps(data))
         response = self.client.post(api_url, id)
         self.assertEqual(response.status_code, status)
@@ -90,4 +90,27 @@ class MonitoringRedirectTests(APITestCase):
         response = self.client.post(api_url, id)
         self.assertEqual(response.status_code, status)
         self.assertEqual(response.data, data)
-  
+    
+    
+    @requests_mock.Mocker(kw= 'mock')    
+    def teste_create_tutoring(self, **kwargs):
+        
+        id= self.valid_payload
+        api_url = '/create_tutoring/'
+        request_url = 'http://api-monitoria:8001/tutoring/'
+        data = {"Success":"Criado com sucesso"}
+        status = HTTP_200_OK
+
+        kwargs['mock'].post(request_url, text= json.dumps(data))
+        response = self.client.post(api_url, id)
+        self.assertEqual(response.status_code, status)
+        self.assertEqual(response.data, data)
+
+    def teste_error_create_tutoring(self, **kwargs):
+        id= self.valid_payload
+        api_url = '/create_tutoring/'
+        data = {'error': 'Error no servidor'}
+        status =HTTP_500_INTERNAL_SERVER_ERROR
+        response = self.client.post(api_url, id)
+        self.assertEqual(response.status_code, status)
+        self.assertEqual(response.data, data)

--- a/api_user/tests.py
+++ b/api_user/tests.py
@@ -1,3 +1,46 @@
-from django.test import TestCase
+import requests_mock
+from rest_framework.test import APITestCase
+import json
 
-# Create your tests here.
+from rest_framework.status import (
+    HTTP_403_FORBIDDEN,
+    HTTP_200_OK,
+    HTTP_404_NOT_FOUND,
+    HTTP_400_BAD_REQUEST,
+    HTTP_500_INTERNAL_SERVER_ERROR
+)
+
+class ApiUserRedirectTests(APITestCase):
+    def setUp(self):
+        self.valid_payload = {
+            'user_account_id':'1'
+        }
+
+        self.invalid_payload = {
+            'user_account_id':''
+        }
+    
+    @requests_mock.Mocker(kw='mock')
+    def test_get_user(self, **kwargs):
+        id = self.valid_payload
+        api_url = '/get_user/'
+        request_url = 'http://api-monitoria:8001/user/1/'
+        status = HTTP_200_OK
+        data = {"Teste": "teste"}
+
+        kwargs['mock'].get(request_url, text=json.dumps(data))
+
+        response = self.client.post(api_url,id)
+
+        self.assertEqual(response.status_code, status)
+        self.assertEqual(response.data['Teste'], "teste")
+
+    def test_error_get_user(self, **kwargs):
+        id = self.invalid_payload
+        api_url = '/get_user/'
+        status = HTTP_500_INTERNAL_SERVER_ERROR
+        data = {'error': 'Error no servidor'}
+
+        response = self.client.post(api_url, id)
+        self.assertEqual(response.status_code, status)
+        self.assertEqual(response.data, data)


### PR DESCRIPTION
## Issue resolvida

[[REFACTOR] Testar API Gateway  ](https://github.com/fga-eps-mds/2019.1-MaisMonitoria-api/tree/REFACTOR-Testar-Api-Gateway)

## Comentário

Realizado cobertura de 85% nos testes das funcionalidades da api Gateway, utilizando APITestCase, ferramenta de testes padrão do DjangoRestFramework .
