### PR TITLE
[US27] Tela de perfil do monitor

### DIFF
--- a/api_user/tests.py
+++ b/api_user/tests.py
@@ -33,7 +33,11 @@ class ApiUserRedirectTests(APITestCase):
             'monitor_id': '1',
 
         }
-
+        
+        self.invalid_payload_teste = {
+            'access_token':'',
+            'monitor_id': '',
+        }
 
    
 
@@ -51,6 +55,16 @@ class ApiUserRedirectTests(APITestCase):
         response = self.client.post(api_url,request_id)
         self.assertEqual(response.status_code, request_status)
         self.assertEqual(response.data['Teste'], "teste")
+
+    def test_error_get_monitor(self, **kwargs):
+        request_id = self.invalid_payload_teste
+        api_url = '/get_monitor/'
+        request_status = status.HTTP_500_INTERNAL_SERVER_ERROR
+        data = '{"error": "Falha de autentica\\u00e7\\u00e3o"}'
+        response = self.client.post(api_url, request_id )
+        self.assertEqual(response.status_code, request_status)
+        self.assertEqual(response.data, data)
+
           
     @mock.patch('firebase_admin.auth.verify_id_token', mock.Mock(return_value={ 'uid': '1','id':'1'}))
     @requests_mock.Mocker(kw='mock')

--- a/api_user/tests.py
+++ b/api_user/tests.py
@@ -17,7 +17,8 @@ import mock
 class ApiUserRedirectTests(APITestCase):
     def setUp(self):
         self.id={
-            'id': '1'
+            'id': '1',
+            
         }
         self.valid_payload = {
              'access_token': '123'
@@ -27,9 +28,31 @@ class ApiUserRedirectTests(APITestCase):
         self.invalid_payload = {
             'access_token':''
         }
+        self.valid_payload_teste={
+            'access_token': '123',
+            'monitor_id': '1',
+
+        }
+
+
    
+
     @mock.patch('firebase_admin.auth.verify_id_token', mock.Mock(return_value={ 'uid': '1','id':'1'}))
-    @mock.patch('api.utils.verify_auth', mock.Mock(return_value={ 'id':'1' }))
+    @requests_mock.Mocker(kw='mock')
+    def test_get_monitor(self, **kwargs):
+        request_id = self.valid_payload_teste
+        api_url = '/get_monitor/'
+        request_url = 'http://api-monitoria:8001/user/1'
+        request_status = status.HTTP_200_OK
+        data = {"Teste": "teste"}
+
+        kwargs['mock'].get(request_url, text=json.dumps(data))
+
+        response = self.client.post(api_url,request_id)
+        self.assertEqual(response.status_code, request_status)
+        self.assertEqual(response.data['Teste'], "teste")
+          
+    @mock.patch('firebase_admin.auth.verify_id_token', mock.Mock(return_value={ 'uid': '1','id':'1'}))
     @requests_mock.Mocker(kw='mock')
     def test_get_user(self, **kwargs):
         request_id = self.valid_payload
@@ -52,3 +75,6 @@ class ApiUserRedirectTests(APITestCase):
         response = self.client.post(api_url, request_id )
         self.assertEqual(response.status_code, request_status)
         self.assertEqual(response.data, data)
+    
+
+    

--- a/api_user/urls.py
+++ b/api_user/urls.py
@@ -1,8 +1,9 @@
-from .views import get_user, update_user, create_user
+from .views import get_user, update_user, create_user, get_monitor
 from django.urls import path
 
 urlpatterns = [
     path('get_user/', get_user),
     path('update_user/', update_user),
+    path('get_monitor/', get_monitor),
     path('create_user/', create_user)
 ]

--- a/api_user/views.py
+++ b/api_user/views.py
@@ -83,7 +83,7 @@ def create_user(request):
 @api_view(["POST"])
 def get_monitor(request):
     token = request.data['access_token']
-    auth_response = registry_auth(token)
+    auth_response =  verify_auth(token)
 
     if auth_response['is_auth']:
         param = str(request.data['monitor_id'])

--- a/api_user/views.py
+++ b/api_user/views.py
@@ -79,3 +79,18 @@ def create_user(request):
         }
         return Response(data=json.dumps(respose_json), 
                         status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+@api_view(["POST"])
+def get_monitor(request):
+    token = request.data['access_token']
+    auth_response = registry_auth(token)
+
+    if auth_response['is_auth']:
+        param = str(request.data['monitor_id'])
+        return get_request(URL, ROUTE, param)
+    else:
+        respose_json = {
+            'error': 'Falha de autenticação'
+        }
+        return Response(data=json.dumps(respose_json), 
+                         status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## Issue resolvida

[[US27] Tela de perfil do monitor](https://github.com/fga-eps-mds/2019.1-MaisMonitoria/issues/159)

## Comentário

Para receber as informações do monitor será feita requisição no método get_monitor que está descrito na API gateway, esse método é o responsável por retornar todos os dados do monitor, assim como: Nome, curso, telegram, descrição, sua foto de perfil e suas monitorias cadastradas.
O método: 
![image](https://user-images.githubusercontent.com/44438409/59151623-9f65cb80-8a0c-11e9-93fc-a424fd4ec95e.png)

